### PR TITLE
Supports Dashboard v2.2.5

### DIFF
--- a/CIS-Alert-Notifier.ps1
+++ b/CIS-Alert-Notifier.ps1
@@ -30,7 +30,7 @@ $command = $myconnection.CreateCommand()
 #$UserTable.Load($command.ExecuteReader())
 
 #Get unread alerts
-$command.CommandText = "select AlertTb.id, AlertTb.title, UserTb.first_name, UserTb.email from dbo.alert_instance as AlertTb inner join dbo.ccpd_user as UserTb on AlertTb.recipient_id = UserTb.id where AlertTb.is_read=0 and AlertTb.id>" + $LastReadRec + " order by AlertTb.id;"
+$command.CommandText = "select AlertTb.id, AlertTb.title, AlertTb.message, UserTb.first_name, UserTb.email from dbo.alert_instance as AlertTb inner join dbo.ccpd_user as UserTb on AlertTb.recipient_id = UserTb.id where AlertTb.is_read=0 and AlertTb.id>" + $LastReadRec + " order by AlertTb.id;"
 $AlertTable = New-Object System.Data.DataTable
 $AlertTable.Load($command.ExecuteReader())
 
@@ -41,14 +41,25 @@ foreach ($Row in $AlertTable)
 {
     $command.CommandText = "select element_name, element_value from dbo.alert_instance_data where alert_instance_id=" + $Row.id + ";";
     $reader = $command.ExecuteReader()
+    $count = 0
 
     $outputl = "<p>" + $Row.first_name + ",</p><p>You have a new alert in the CIS-CAT Pro Dashboard.</p>"
     $outputl = $outputl + "<p>"
 
+    #Old way for version <2.2.5
     while ($reader.Read()) {
-        $outputl = $outputl + $Reader["element_name"].ToString() + " : " + $Reader["element_value"].ToString() + "<br>"
+        if (($Reader["element_value"].ToString()).Length -gt 0) {
+            $outputl = $outputl + $Reader["element_name"].ToString() + " : " + $Reader["element_value"].ToString() + "<br>"
+            $count++
+        }
     }
     $reader.close()
+    
+    #New way for version =>2.2.5
+    if ($count -eq 0) {
+        $outputl = $outputl + $Row.message + "<br>"
+    }
+
     $outputl = $outputl + "</p>"
 
     #send the email


### PR DESCRIPTION
In Dashboard version 2.2.5 the alert table was changed to include the message along with the other alert data. However not all messages come through that way. Assuming this is the way of the future, the script was changed to support that while (hopefully) providing backwards compatibility.